### PR TITLE
feat: add option to allow tagging of version bump commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Filenames to ignore, separated by commas"
     required: false
     default: ""
+  tag_version_bump_commit:
+    description: "Set to 'true' to create tag on the version bump commit instead"
+    required: false
+    default: 'false'
 outputs:
   version:
     description: New version
@@ -37,4 +41,3 @@ runs:
   main: "lib/main.js"
 # [bump]
 # 2.0.53 // TODO regex match the rag
-

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -31,6 +31,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const exec_1 = require("@actions/exec");
 const core = __importStar(require("@actions/core"));
 const support_1 = require("./support");
+let curExecStdOut = '';
 exports.default = ({ USER_NAME, USER_EMAIL, MESSAGE, GITHUB_TOKEN, tagName, tagMsg, branch, }) => __awaiter(void 0, void 0, void 0, function* () {
     try {
         if (!process.env.GITHUB_TOKEN) {
@@ -43,6 +44,9 @@ exports.default = ({ USER_NAME, USER_EMAIL, MESSAGE, GITHUB_TOKEN, tagName, tagM
         const options = {
             cwd: process.env.GITHUB_WORKSPACE,
             listeners: {
+                stdout: (data) => {
+                    curExecStdOut = data.toString();
+                },
                 stdline: core.debug,
                 stderr: core.debug,
                 debug: core.debug,
@@ -65,6 +69,8 @@ exports.default = ({ USER_NAME, USER_EMAIL, MESSAGE, GITHUB_TOKEN, tagName, tagM
         yield exec_1.exec('git', ['checkout', branch], options);
         yield exec_1.exec('git', ['merge', 'bump_tmp_'], options);
         yield push({ branch, options });
+        yield exec_1.exec('git', ['rev-parse', 'HEAD'], options);
+        return curExecStdOut.trim();
     }
     catch (err) {
         core.setFailed(err.message);

--- a/lib/createTag.js
+++ b/lib/createTag.js
@@ -31,7 +31,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.createTag = void 0;
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
-function createTag({ tagName, tagMsg = '' }) {
+function createTag({ tagName, tagMsg = '', gitSha }) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (!process.env.GITHUB_WORKSPACE || !process.env.GITHUB_REPOSITORY) {
@@ -64,7 +64,7 @@ function createTag({ tagName, tagMsg = '' }) {
             repo,
             tag: tagName,
             message: tagMsg,
-            object: process.env.GITHUB_SHA,
+            object: gitSha,
             type: 'commit',
         });
         const newReference = yield git.git.createRef({

--- a/lib/main.js
+++ b/lib/main.js
@@ -88,21 +88,20 @@ function run() {
         }
         const tagName = prefix ? prefix + '_' + newVersion : newVersion;
         const tagMsg = `${support_1.capitalize(prefix) + ' '}Version ${newVersion} [skip ci]`;
-        yield Promise.all([
-            commit_1.default({
-                USER_EMAIL: 'bump-version@version.com',
-                USER_NAME: 'bump_version',
-                GITHUB_TOKEN: githubToken,
-                MESSAGE: tagMsg,
-                tagName,
-                tagMsg,
-                branch,
-            }),
-            createTag_1.createTag({
-                tagName,
-                tagMsg,
-            }),
-        ]);
+        const gitSha = yield commit_1.default({
+            USER_EMAIL: 'bump-version@version.com',
+            USER_NAME: 'bump_version',
+            GITHUB_TOKEN: githubToken,
+            MESSAGE: tagMsg,
+            tagName,
+            tagMsg,
+            branch,
+        });
+        yield createTag_1.createTag({
+            tagName,
+            tagMsg,
+            gitSha: core.getInput('tag_version_bump_commit').toLowerCase() === 'true' ? gitSha : process.env.GITHUB_SHA
+        });
         console.log('setting output version=' + newVersion + ' prefix=' + prefix);
         yield createAnnotation_1.createAnnotations({ githubToken, newVersion: tagMsg, linesReplaced });
         core.setOutput('version', newVersion);

--- a/src/createTag.ts
+++ b/src/createTag.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
-export async function createTag({ tagName, tagMsg = '' }) {
+export async function createTag({ tagName, tagMsg = '', gitSha }) {
     if (!process.env.GITHUB_WORKSPACE || !process.env.GITHUB_REPOSITORY) {
         console.log(
             'not in Github Action, skipping tag creation with github api'
@@ -37,7 +37,7 @@ export async function createTag({ tagName, tagMsg = '' }) {
         repo,
         tag: tagName,
         message: tagMsg,
-        object: process.env.GITHUB_SHA as string,
+        object: gitSha,
         type: 'commit',
     })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,8 +67,7 @@ async function run() {
     }
     const tagName = prefix ? prefix + '_' + newVersion : newVersion
     const tagMsg = `${capitalize(prefix) + ' '}Version ${newVersion} [skip ci]`
-    await Promise.all([
-        commit({
+    const gitSha = await commit({
             USER_EMAIL: 'bump-version@version.com',
             USER_NAME: 'bump_version',
             GITHUB_TOKEN: githubToken,
@@ -76,12 +75,13 @@ async function run() {
             tagName,
             tagMsg,
             branch,
-        }),
-        createTag({
-            tagName,
-            tagMsg,
-        }),
-    ])
+    })
+
+    await createTag({
+        tagName,
+        tagMsg,
+        gitSha: core.getInput('tag_version_bump_commit').toLowerCase() === 'true' ? gitSha : process.env.GITHUB_SHA
+    })
     console.log('setting output version=' + newVersion + ' prefix=' + prefix)
     await createAnnotations({ githubToken, newVersion: tagMsg, linesReplaced })
     core.setOutput('version', newVersion)


### PR DESCRIPTION
closes #13

added config to enable this feature explicitly because this may cause breaking changes for users that depends on the old tagging behaviour