### PR TITLE
Use more accurate Github env variable for the owner of the repo

### DIFF
--- a/lib/createTag.js
+++ b/lib/createTag.js
@@ -46,7 +46,8 @@ function createTag({ tagName, tagMsg = '' }) {
         console.log(`creating tag "${tagName}"`);
         // Check for existing tag
         const git = new github.GitHub(process.env.GITHUB_TOKEN);
-        const owner = process.env.GITHUB_ACTOR;
+        // const owner = process.env.GITHUB_ACTOR;
+        const owner = "AppMonet"
         const repo = (_a = process.env.GITHUB_REPOSITORY) === null || _a === void 0 ? void 0 : _a.split('/').pop();
         const tags = yield git.repos.listTags({
             owner,

--- a/lib/createTag.js
+++ b/lib/createTag.js
@@ -46,8 +46,8 @@ function createTag({ tagName, tagMsg = '' }) {
         console.log(`creating tag "${tagName}"`);
         // Check for existing tag
         const git = new github.GitHub(process.env.GITHUB_TOKEN);
-        // const owner = process.env.GITHUB_ACTOR;
-        const owner = "AppMonet"
+        const owner = process.env.GITHUB_REPOSITORY_OWNER;
+        // const owner = "AppMonet"
         const repo = (_a = process.env.GITHUB_REPOSITORY) === null || _a === void 0 ? void 0 : _a.split('/').pop();
         const tags = yield git.repos.listTags({
             owner,

--- a/lib/createTag.js
+++ b/lib/createTag.js
@@ -47,7 +47,6 @@ function createTag({ tagName, tagMsg = '' }) {
         // Check for existing tag
         const git = new github.GitHub(process.env.GITHUB_TOKEN);
         const owner = process.env.GITHUB_REPOSITORY_OWNER;
-        // const owner = "AppMonet"
         const repo = (_a = process.env.GITHUB_REPOSITORY) === null || _a === void 0 ? void 0 : _a.split('/').pop();
         const tags = yield git.repos.listTags({
             owner,

--- a/src/createTag.ts
+++ b/src/createTag.ts
@@ -16,8 +16,7 @@ export async function createTag({ tagName, tagMsg = '' }) {
     console.log(`creating tag "${tagName}"`)
     // Check for existing tag
     const git = new github.GitHub(process.env.GITHUB_TOKEN)
-    // const owner = process.env.GITHUB_ACTOR as string
-    const owner = "AppMonet"
+    const owner = process.env.GITHUB_REPOSITORY_OWNER as string
     const repo = process.env.GITHUB_REPOSITORY?.split('/').pop() as string
 
     const tags = await git.repos.listTags({

--- a/src/createTag.ts
+++ b/src/createTag.ts
@@ -16,7 +16,8 @@ export async function createTag({ tagName, tagMsg = '' }) {
     console.log(`creating tag "${tagName}"`)
     // Check for existing tag
     const git = new github.GitHub(process.env.GITHUB_TOKEN)
-    const owner = process.env.GITHUB_ACTOR as string
+    // const owner = process.env.GITHUB_ACTOR as string
+    const owner = "AppMonet"
     const repo = process.env.GITHUB_REPOSITORY?.split('/').pop() as string
 
     const tags = await git.repos.listTags({


### PR DESCRIPTION
Based off this issue #22 

Use env variable `GITHUB_REPOSITORY_OWNER` instead of `GITHUB_ACTOR`. More details -> https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables